### PR TITLE
Upgrade pyjwt to 1.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     install_requires=[
         # pinned to avoid unintentional updates
         'cryptography==2.0.0',
-        'pyjwt==1.5.2',
+        'pyjwt==1.5.3',
     ],
     zip_safe=True,
 )


### PR DESCRIPTION
This fixes the `_warn_sign_verify_deprecated` error on every call.