### PR TITLE
Allow audience verification override

### DIFF
--- a/mbq/tokens/decoder.py
+++ b/mbq/tokens/decoder.py
@@ -31,7 +31,7 @@ class Decoder:
 
         self._allowed_audiences = set(allowed_audiences)
 
-    def decode(self, token, verify_audience=True):
+    def _decode(self, token, verify_audience=True):
         try:
             decoded_token = jwt.decode(
                 token,
@@ -47,6 +47,12 @@ class Decoder:
             raise exceptions.TokenError('`aud` claim is not in allowed_audiences')
 
         return decoded_token
+
+    def decode(self, token):
+        return self._decode(token)
+
+    def decode_with_unknown_audience(self, token):
+        return self._decode(token, verify_audience=False)
 
     def decode_header(self, header):
         err_msg = '`header` must be a string in the form "Bearer <token>"'

--- a/mbq/tokens/decoder.py
+++ b/mbq/tokens/decoder.py
@@ -31,7 +31,7 @@ class Decoder:
 
         self._allowed_audiences = set(allowed_audiences)
 
-    def decode(self, token):
+    def decode(self, token, verify_audience=True):
         try:
             decoded_token = jwt.decode(
                 token,
@@ -43,7 +43,7 @@ class Decoder:
             msg = '`token` could not be decoded. {}'.format(e)
             raise exceptions.TokenError(msg)
 
-        if decoded_token['aud'] not in self._allowed_audiences:
+        if verify_audience and decoded_token['aud'] not in self._allowed_audiences:
             raise exceptions.TokenError('`aud` claim is not in allowed_audiences')
 
         return decoded_token

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -57,6 +57,16 @@ class DecoderTest(TestCase):
         with self.assertRaises(tokens.TokenError):
             decoder.decode(make_jwt(audience='different_audience'))
 
+    def test_decode_skip_verify_audience(self):
+        decoder = tokens.Decoder(certificate=keys.CERTIFICATE, allowed_audiences={'test_audience'})
+        decoded_token = decoder.decode(
+            make_jwt(audience='different_audience'),
+            verify_audience=False,
+        )
+        self.assertEqual(decoded_token['aud'], 'different_audience')
+        self.assertEqual(decoded_token['iss'], 'https://example.auth0.com/')
+        self.assertEqual(decoded_token['sub'], 'abc123|test@example.com')
+
     def test_decode(self):
         decoder = tokens.Decoder(certificate=keys.CERTIFICATE, allowed_audiences={'test_audience'})
         decoded_token = decoder.decode(make_jwt())

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -57,11 +57,10 @@ class DecoderTest(TestCase):
         with self.assertRaises(tokens.TokenError):
             decoder.decode(make_jwt(audience='different_audience'))
 
-    def test_decode_skip_verify_audience(self):
+    def test_decode_with_unknown_audience(self):
         decoder = tokens.Decoder(certificate=keys.CERTIFICATE, allowed_audiences={'test_audience'})
-        decoded_token = decoder.decode(
-            make_jwt(audience='different_audience'),
-            verify_audience=False,
+        decoded_token = decoder.decode_with_unknown_audience(
+            make_jwt(audience='different_audience')
         )
         self.assertEqual(decoded_token['aud'], 'different_audience')
         self.assertEqual(decoded_token['iss'], 'https://example.auth0.com/')


### PR DESCRIPTION
Allow for skipping audience verification when decoding `id_tokens` forwarded from BFFs