### PR TITLE
Token class

### DIFF
--- a/mbq/tokens/decoder.py
+++ b/mbq/tokens/decoder.py
@@ -13,8 +13,9 @@ class Token:
     Convenience class for easy access to the fields of a JWT.
 
     All properties use the full name of the claims specified by the
-    JWT RFC[1]. Additionally, `expires_at` is exposed as an alias to
-    `expiration_time` for consistency.
+    JWT RFC[1] except for `expires_at` which was changed from
+    `expiration_time` to avoid implying that the return value is
+    anything other than a datetime.
 
     The `dict` read-only interface (`__getitem__` and `get`) are
     provided for backwards-compatibility only; new code should use
@@ -45,15 +46,11 @@ class Token:
         return self._decoded.get('aud')
 
     @property
-    def expiration_time(self):
+    def expires_at(self):
         ts = self._decoded.get('exp')
         if ts is None:
             return
         return dt.datetime.fromtimestamp(ts, dt.timezone.utc)
-
-    @property
-    def expires_at(self):
-        return self.expiration_time
 
     @property
     def not_before(self):

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -129,5 +129,4 @@ class DecoderTest(TestCase):
         now = dt.datetime.now(dt.timezone.utc)
         self.assertGreaterEqual(now, token.issued_at)
         self.assertGreaterEqual(now, token.not_before)
-        self.assertGreater(token.expiration_time, now)
         self.assertGreater(token.expires_at, now)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -16,6 +16,7 @@ def make_jwt(audience=None):
     now = dt.datetime.utcnow()
     claims = {
         'aud': audience or 'test_audience',
+        'nbf': now,
         'iat': now,
         'exp': now + dt.timedelta(minutes=1),
         'iss': 'https://example.auth0.com/',
@@ -74,6 +75,7 @@ class DecoderTest(TestCase):
 
         now = since_epoch()
         self.assertGreaterEqual(now, decoded_token['iat'])
+        self.assertGreaterEqual(now, decoded_token['nbf'])
         self.assertGreater(decoded_token['exp'], now)
 
     def test_decode_header_bad_header(self):
@@ -112,3 +114,20 @@ class DecoderTest(TestCase):
         decoder.decode_header('bearer test')
         args, kwargs = decoder.decode.call_args
         self.assertEqual(args[0], 'test')
+
+    def test_decode_with_token_class(self):
+        raw_jwt = make_jwt()
+
+        decoder = tokens.Decoder(certificate=keys.CERTIFICATE, allowed_audiences={'test_audience'})
+        token = decoder.decode(raw_jwt)
+
+        self.assertEqual(token.raw, raw_jwt)
+        self.assertEqual(token.audience, 'test_audience')
+        self.assertEqual(token.issuer, 'https://example.auth0.com/')
+        self.assertEqual(token.subject, 'abc123|test@example.com')
+
+        now = dt.datetime.now(dt.timezone.utc)
+        self.assertGreaterEqual(now, token.issued_at)
+        self.assertGreaterEqual(now, token.not_before)
+        self.assertGreater(token.expiration_time, now)
+        self.assertGreater(token.expires_at, now)


### PR DESCRIPTION
I wanted to provide a better response than a `dict` so users don't have to know the abbreviations from the JWT and so it's immutable.

My thinking is that these objects can be assigned directly to requests to make it really easy to interact with.

```python
if request.id_token.audience == 'some-audience`:
    # do something interesting
```